### PR TITLE
GEAR-43 Fix silent failures in SlackNotify and improve email parsing logs

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
-"""
-Build script for the Slack notification system for unattended upgrades
+"""Build script for the Slack notification system for unattended upgrades
 
 Author: @tom4897
 Date: September 2025
@@ -12,36 +11,37 @@ import re
 import shutil
 import subprocess
 from datetime import datetime
-from pathlib import Path
-from typing import Optional
 
 
 def get_block_content(block_id: str) -> list[str]:
     block_content_py = ""
-    with open(f"build/blocks/{block_id}.txt", "r") as file:
+    with open(f"build/blocks/{block_id}.txt") as file:
         block_content_py = file.read()
 
     block_content_j2 = ""
-    with open(f"build/blocks/{block_id}.j2", "r") as file:
+    with open(f"build/blocks/{block_id}.j2") as file:
         block_content_j2 = file.read()
 
     return [block_content_py, block_content_j2]
 
+
 def get_git_branch():
     """Get the Git branch from Git."""
     try:
-        result = subprocess.run(['git', 'branch', '--show-current'], capture_output=True, text=True)
+        result = subprocess.run(["git", "branch", "--show-current"], check=False, capture_output=True, text=True)
         return result.stdout.strip()
     except Exception as e:
         print(f"Warning: Could not execute Git command: {e}")
         return "unknown"
+
 
 def get_git_commit_hash():
     """Get the short commit hash from Git."""
     try:
         # Get the short commit hash (first 7 characters)
         result = subprocess.run(
-            ['git', 'rev-parse', '--short', 'HEAD'],
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=False,
             capture_output=True,
             text=True,
         )
@@ -53,6 +53,7 @@ def get_git_commit_hash():
     except Exception as e:
         print(f"Warning: Could not execute Git command: {e}")
         return "unknown"
+
 
 def main() -> None:
     src_dir = os.path.abspath("src")
@@ -69,7 +70,7 @@ def main() -> None:
 
     content = ""
     try:
-        with open(dist_filepath_tmp, "r") as file:
+        with open(dist_filepath_tmp) as file:
             content = file.read()
     except FileNotFoundError:
         print(f"File {dist_filepath_tmp} not found")
@@ -81,10 +82,10 @@ def main() -> None:
     dist_filepath_py = shutil.copy(dist_filepath_tmp, os.path.join(dist_dir, dist_filename_py))
     dist_filepath_j2 = shutil.copy(dist_filepath_tmp, os.path.join(dist_dir, dist_filename_j2))
 
-     # Get full blocks with markers included
+    # Get full blocks with markers included
     block_list = []
-    block_Re = re.compile(r"(?s)# BUILD::.*?::.*?\n.*?# BUILD::.*?::END", re.MULTILINE)
-    block_id_re = re.compile(r"(?s)# BUILD::(.*?)::(.*?)")
+    block_Re = re.compile(r"(?s)^(?:    |\t)?# BUILD::.*?::.*?\n.*?^(?:    |\t)?# BUILD::.*?::END", re.MULTILINE)
+    block_id_re = re.compile(r"(?s)^(?:    |\t)?# BUILD::(.*?)::(.*?)")
     content_py = content
     content_j2 = content
     for match in block_Re.finditer(content):
@@ -119,6 +120,7 @@ def main() -> None:
     os.unlink(dist_filepath_tmp)
 
     print(f"Successfully built {dist_filename_py} and {dist_filename_j2}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/notifyslack.py
+++ b/src/notifyslack.py
@@ -14,15 +14,16 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
-from typing import Any, ClassVar, TypedDict
-from email.header import decode_header, make_header
 from email import message_from_bytes
+from email.header import decode_header, make_header
+from enum import Enum
+from typing import Any, ClassVar, TypedDict  # noqa: F401
 
 import requests
 
 # BUILD::CONFIG_CLASS::REPLACE
 from config import ConfigsDict, load_config_from_file
+
 # BUILD::CONFIG_CLASS::END
 # BUILD::LOG_DIR::REPLACE
 BASE_LOG_DIR = "./logs/notifyslack"
@@ -51,6 +52,7 @@ SLACK_MAX_CHARS = 12000  # Slack's actual character limit per message
 # This debug code will be removed during build
 print("Debug: log level set to", LOG_LEVEL)
 # BUILD::DEBUG_CODE::END
+
 
 class LoggerManager:
     """Manages the logger for the notification system."""
@@ -82,6 +84,7 @@ class LoggerManager:
         if self.logger is None:
             return self.setup()
         return self.logger
+
 
 _logger = LoggerManager(BASE_LOG_DIR).get_logger()
 
@@ -174,34 +177,38 @@ class ContentParser:
 
         Returns a tuple of (subject, decoded_body).
         """
-        with open(filepath, "rb") as f:
-            raw = f.read()
+        try:
+            with open(filepath, "rb") as f:
+                raw = f.read()
 
-        # Strip leading mbox 'From ' line if present
-        if raw.startswith(b"From "):
-            nl = raw.find(b"\n")
-            if nl != -1:
-                raw = raw[nl + 1 :]
+            # Strip leading mbox 'From ' line if present
+            if raw.startswith(b"From "):
+                nl = raw.find(b"\n")
+                if nl != -1:
+                    raw = raw[nl + 1 :]
 
-        msg = message_from_bytes(raw)
+            msg = message_from_bytes(raw)
 
-        # Decode RFC 2047 encoded email subject (e.g., =?utf-8?q?...?= format)
-        subject = str(make_header(decode_header(msg.get("Subject", ""))))
+            # Decode RFC 2047 encoded email subject (e.g., =?utf-8?q?...?= format)
+            subject = str(make_header(decode_header(msg.get("Subject", ""))))
 
-        body = ""
-        if msg.is_multipart():
-            for part in msg.walk():
-                if part.get_content_type() == "text/plain":
-                    payload = part.get_payload(decode=True) or b""
-                    charset = part.get_content_charset() or "utf-8"
-                    body = payload.decode(charset, errors="replace")
-                    break
-        else:
-            payload = msg.get_payload(decode=True) or b""
-            charset = msg.get_content_charset() or "utf-8"
-            body = payload.decode(charset, errors="replace")
+            body = ""
+            if msg.is_multipart():
+                for part in msg.walk():
+                    if part.get_content_type() == "text/plain":
+                        payload = part.get_payload(decode=True) or b""
+                        charset = part.get_content_charset() or "utf-8"
+                        body = payload.decode(charset, errors="replace")
+                        break
+            else:
+                payload = msg.get_payload(decode=True) or b""
+                charset = msg.get_content_charset() or "utf-8"
+                body = payload.decode(charset, errors="replace")
 
-        return subject, body
+            return subject, body
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _logger.error("Error parsing email: %s", e)
+        return "", ""
 
     def find_log_indices(self, lines: list[str]) -> tuple[int | None, int | None]:
         """Find the start and end indices of the package installation log."""
@@ -550,6 +557,15 @@ class UpdateNotifier:
         input_file, tmp_file = self.email_parser.process_input()
         _logger.info("Input file: %s, Temporary file: %s", input_file, tmp_file)
 
+        # Log file content for debugging (file will be read again in parse_email)
+        file_to_log = tmp_file if tmp_file else input_file
+        try:
+            with open(file_to_log, encoding="utf-8") as f:
+                file_content = f.read()
+                _logger.info("File content:\n%s", file_content)
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            _logger.error("Failed to read file content for logging: %s", e)
+
         try:
             # Parse and decode email
             subject, decoded_body = self.email_parser.parse_email(input_file)
@@ -684,9 +700,9 @@ def main() -> None:
     _logger.info("Starting notification script")
 
     # Load configuration
-# BUILD::SLACK_CONFIG::REPLACE
+    # BUILD::SLACK_CONFIG::REPLACE
     config_dict: ConfigsDict = load_config_from_file()
-# BUILD::SLACK_CONFIG::END
+    # BUILD::SLACK_CONFIG::END
     # Create and run notifier
     notifier = UpdateNotifier(configs=config_dict)
     notifier.process_and_notify()


### PR DESCRIPTION
This pull request refactors and improves the `build.py` build script and the main notification logic in `src/notifyslack.py`. The changes focus on code cleanliness, error handling, and logging for better maintainability and debugging. The most important changes are grouped below:

**Logging and Error Handling Enhancements (`src/notifyslack.py`):**

* Added detailed logging for input file content before parsing the email, improving traceability and debugging of notification processing.
* Improved error handling in the `parse_email` method: now logs errors and returns empty values on failure, making the system more robust against malformed input. [[1]](diffhunk://#diff-a0ee0adb00c39d66c6713b45acad4c5b3f270c46f662a473b95bba457fc794deR180) [[2]](diffhunk://#diff-a0ee0adb00c39d66c6713b45acad4c5b3f270c46f662a473b95bba457fc794deR209-R211)
* Minor code cleanup and reordering of imports for clarity and style consistency. [[1]](diffhunk://#diff-a0ee0adb00c39d66c6713b45acad4c5b3f270c46f662a473b95bba457fc794deL17-R26) [[2]](diffhunk://#diff-a0ee0adb00c39d66c6713b45acad4c5b3f270c46f662a473b95bba457fc794deR56) [[3]](diffhunk://#diff-a0ee0adb00c39d66c6713b45acad4c5b3f270c46f662a473b95bba457fc794deR88)

**Build Script Improvements (`build.py`):**
_These changes are needed for when the pre-commit reformats the file._

* Improved regular expressions for block extraction to more accurately handle indentation and block markers, which makes the build process more robust.
* Standardized file opening (removed unnecessary `"r"` mode and simplified code), and added `check=False` to `subprocess.run` calls for safer git operations. [[1]](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eL15-R44) [[2]](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eL72-R73)
* Minor formatting and cleanup, including docstring formatting and removal of unused imports. [[1]](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eL3-R3) [[2]](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eL15-R44)